### PR TITLE
fixed race condition

### DIFF
--- a/app/src/main/java/com/example/beyondpomodoro/sessiontype/Session.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/sessiontype/Session.kt
@@ -2,6 +2,8 @@ package com.example.beyondpomodoro.sessiontype
 
 import android.content.Context
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Entity
 data class Session (
@@ -72,6 +74,11 @@ interface SessionDao {
 
     @Query("SELECT * FROM session WHERE sid = :sid")
     suspend fun getSession(sid: Int): Session
+
+    @Query("SELECT title FROM session WHERE sid = :sid")
+    fun _getTitle(sid: Int): Flow<String>
+
+    fun getTitle(sid: Int) = _getTitle(sid).distinctUntilChanged()
 
     @Query("SELECT * FROM session ORDER BY used_at")
     suspend fun getSessions(): List<Session>

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeFragment.kt
@@ -51,8 +51,12 @@ open class HomeFragment : TimerFragment() {
         super.addButtons()
         view?.let { setupVisualBlocks(it) }
         updateVisualBlocks(sessionTimeSeconds)
+    }
+
+    override fun updateTitle(t: String) {
+        super.updateTitle(t)
         view?.findViewById<TextView>(R.id.activity_name).apply {
-            this?.text = title
+            this?.text = t
         }
     }
 

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
@@ -19,6 +19,7 @@ import com.example.beyondpomodoro.MainActivity
 import com.example.beyondpomodoro.R
 import com.example.beyondpomodoro.sessiontype.Session
 import com.example.beyondpomodoro.sessiontype.SessionDao
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 open class TimerFragment : Fragment() {
@@ -81,11 +82,18 @@ open class TimerFragment : Fragment() {
         // fetch most recent session
         val cls = this
         lifecycleScope.launch {
+            println("DEBUG: launching after service connected coroutine")
             sharedData.sid?.let {
                 println("DEBUG: sid has been set")
-                sessionDao?.getSession(it).apply {
-                    this?.let { s ->
-                        readSession(s)
+                sessionDao?.getSession(it)?.let { s ->
+                    readSession(s)
+                }
+                lifecycleScope.launch {
+                    sessionDao?.getTitle(it)?.let { s ->
+                        s.collect { t ->
+                            title = t
+                            updateTitle(t)
+                        }
                     }
                 }
             }?: run {
@@ -112,6 +120,10 @@ open class TimerFragment : Fragment() {
                 updateVisualBlocks(it)
             })
         }
+    }
+
+    open fun updateTitle(t: String) {
+
     }
 
     open fun startSession() {


### PR DESCRIPTION
#11 should be fixed now. The issue was a race condition between the DB write and view creation. Now a new Dao function `getTitle` receives a `Flow` on which we collect and update the activity name in HomeFragment. 