### PR TITLE
bug: activating and disabling observers based on other observers = NO

### DIFF
--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
@@ -57,6 +57,7 @@ class BreakFragment : TimerFragment() {
     }
 
     override fun onTimerFinish() {
+        super.onTimerFinish()
         // hide end button
         endButton.visibility = View.INVISIBLE
         controlButtonAction {

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
@@ -267,6 +267,8 @@ open class TimerFragment : Fragment() {
     }
 
     open fun onTimerFinish() {
+        // set timer display to zero
+        textViewSeconds.text = convertMinutesToDisplayString(0u)
     }
 
     open fun saveSession() {


### PR DESCRIPTION
I think this gets too complex to figure out the flow. Instead I'm
setting observers only once. I'm using nullable functions which the
Fragment can set to something useful

This is attempting to fix #9 by simplifying the flow. One set of observers only. They call the fragment's UI update functions. Hopefully this should work. Will have to test it out for a week or so.