### PR TITLE
Activity selection confirms before clearing existing session

### DIFF
--- a/app/src/main/java/com/example/beyondpomodoro/SessionInfoFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/SessionInfoFragment.kt
@@ -1,22 +1,26 @@
 package com.example.beyondpomodoro
 
 import android.app.AlertDialog
-import android.content.DialogInterface
+import android.content.*
 import android.os.Bundle
+import android.os.IBinder
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.VERTICAL
 import androidx.recyclerview.widget.RecyclerView
 import com.example.beyondpomodoro.sessiontype.*
+import com.example.beyondpomodoro.ui.home.PomodoroTimer
 import com.example.beyondpomodoro.ui.home.SharedViewModel
+import com.example.beyondpomodoro.ui.home.State
+import com.example.beyondpomodoro.ui.home.TimerService
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.launch
 
@@ -29,6 +33,20 @@ class SessionInfoFragment : Fragment() {
     private var sessionDao: SessionDao? = null
     private var columnCount = 1
     private var sessions: List<SessionType>? = null
+    private var timer: PomodoroTimer? = null
+
+    protected val connection = object: ServiceConnection {
+        private lateinit var binder: TimerService.LocalBinder
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            binder = service as TimerService.LocalBinder
+            timer = binder.timer
+            println("DEBUG: service connected")
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            timer = null
+        }
+    }
 
     protected val sharedData: SharedViewModel by activityViewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,6 +54,47 @@ class SessionInfoFragment : Fragment() {
 
         arguments?.let {
             columnCount = it.getInt(ARG_COLUMN_COUNT)
+        }
+    }
+
+    open fun bindService() {
+        Intent(context, TimerService::class.java).also { intent ->
+            context?.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+        }
+    }
+
+    fun confirmFirst(onConfirmCall: () -> Unit) {
+        // create a new database entry with a new session id and default values of on and off time
+        lifecycleScope.launch {
+            // check if a session already active?
+            if (timer?.state?.value != State.INACTIVE) {
+                val runningSession = sharedData.sid?.let {
+                    sessionDao?.getSession(it)
+                }
+                activity?.let {
+                    // Use the Builder class for convenient dialog construction
+                    val builder = AlertDialog.Builder(it)
+                    val dialogTitle = runningSession?. let{
+                        "Activity ${runningSession.title} is currently running. Cancel it?"
+                    }?: run {
+                        "An activity is already running. Cancel it?"
+                    }
+                    builder.setMessage(dialogTitle)
+                        .setPositiveButton(R.string.cancel_activity_no,
+                            DialogInterface.OnClickListener { dialog, id ->
+                                // User cancelled the dialog
+                                // do nothing
+                            })
+                        .setNegativeButton(R.string.cancel_activity_yes,
+                            DialogInterface.OnClickListener { dialog, id ->
+                                onConfirmCall()
+                            })
+                    // Create the AlertDialog object and return it
+                    builder.create()
+                }?.show()
+            } else {
+                onConfirmCall()
+            }
         }
     }
 
@@ -49,14 +108,15 @@ class SessionInfoFragment : Fragment() {
         // fab action
         view.findViewById<FloatingActionButton>(R.id.newSessionTypeButton).apply {
             setOnClickListener {
-                // create a new database entry with a new session id and default values of on and off time
-                lifecycleScope.launch {
-                    sharedData.sid = sessionDao?.addSession(
-                        Session("", 1500, 300, null, setOf<String>())
-                    )?.toInt()
-
-                    // navigate to Home Fragment
-                    findNavController().navigate(R.id.action_sessionInfoFragment_to_pomodoroFragment)
+                confirmFirst {
+                    timer?.clockReset()
+                    timer?.pomodoroReset()
+                    lifecycleScope.launch {
+                        sharedData.sid = sessionDao?.addSession(
+                            Session("", 1500, 300, null, setOf<String>())
+                        )?.toInt()
+                        findNavController().navigate(R.id.action_sessionInfoFragment_to_pomodoroFragment)
+                    }
                 }
             }
         }
@@ -85,14 +145,24 @@ class SessionInfoFragment : Fragment() {
                     }
 
                     val sessionList = SessionList(sessions!!)
-                    adapter = MySessionInfoRecyclerViewAdapter(sessionList.items, {
-                        context.toast("${it.id}, ${it.title}")
+                    adapter = MySessionInfoRecyclerViewAdapter(sessionList.items, {sessionType ->
+                        if (sharedData.sid == sessionType.id.toInt()) {
+                            // navigate to Home Fragment
+                            findNavController().navigate(R.id.action_sessionInfoFragment_to_pomodoroFragment)
+                        }
+                        else {
+                            confirmFirst {
+                                timer?.clockReset()
+                                timer?.pomodoroReset()
+                                context.toast("${sessionType.id}, ${sessionType.title}")
 
-                        // selected session id saved
-                        sharedData.sid = it.id.toInt()
+                                // selected session id saved
+                                sharedData.sid = sessionType.id.toInt()
 
-                        // navigate to Home Fragment
-                        findNavController().navigate(R.id.action_sessionInfoFragment_to_pomodoroFragment)
+                                // navigate to Home Fragment
+                                findNavController().navigate(R.id.action_sessionInfoFragment_to_pomodoroFragment)
+                            }
+                        }
                     }, { sessionType ->
                         // show confirmation dialog on long click
                         activity?.let {
@@ -124,6 +194,11 @@ class SessionInfoFragment : Fragment() {
             }
         }
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bindService()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
@@ -35,10 +35,10 @@ class BreakFragment : TimerFragment() {
     }
 
     override fun addButtons() {
+        super.addButtons()
+        setSessionTime(breakTimeSeconds)
         notificationTitle("Break time. Stretch. Relax. Hydrate.")
         type("Break")
-        timer.setSessionTime(breakTimeSeconds)
-        super.addButtons()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
@@ -57,6 +57,7 @@ class BreakFragment : TimerFragment() {
     }
 
     override fun onTimerFinish() {
+        super.onTimerFinish()
         // hide end button
         endButton.visibility = View.INVISIBLE
         controlButtonAction {

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeViewModel.kt
@@ -13,7 +13,9 @@ open class HomeViewModel : ViewModel() {
     }
     val text: LiveData<String> = _text
 
-    var numBlocksShow: Int = 9
+    public val numBlocksShow = MutableLiveData<UInt>().apply {
+        value = 9u
+    }
     var imageButtonList: List<ImageView?>? = null
     var tags: MutableMap<String, String> = mutableMapOf()
 

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/PomodoroTimer.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/PomodoroTimer.kt
@@ -82,11 +82,8 @@ class PomodoroTimer(sessionTimeSeconds: UInt) {
     }
 
     fun setSessionTime(s: UInt) {
+        println("DEBUG: setSessionTime $s")
         sessionTimeSeconds.apply {
-            value = s
-        }
-
-        sessionTimeSecondsLeft.apply {
             value = s
         }
     }

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/SetTimeDialogFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/SetTimeDialogFragment.kt
@@ -19,7 +19,10 @@ class SetTimeDialogFragment(caller: TimerFragment): DialogFragment() {
 
             setOnClickListener {
                 when(minutesEditText.text.isNotEmpty()) {
-                    true -> caller.setSessionTime(minutesEditText.text.toString().toUInt() * 60u)
+                    true -> {
+                        caller.setSessionTime(minutesEditText.text.toString().toUInt() * 60u)
+                        caller.timerReset()
+                    }
                 }
                 dismiss()
             }

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
@@ -267,6 +267,8 @@ open class TimerFragment : Fragment() {
     }
 
     open fun onTimerFinish() {
+        // set timer display to zero
+        textViewSeconds.text = convertMinutesToDisplayString(0u)
     }
 
     open fun saveSession() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,7 @@
     <string name="delete_activity_confirmation">Delete this activity?</string>
     <string name="delete_activity_yes">Yes</string>
     <string name="delete_activity_cancel">Cancel</string>
+    <string name="cancel_current_activity_confirmation">There is an activity running already. Do you want to cancel it and start a new one?</string>
+    <string name="cancel_activity_no">No</string>
+    <string name="cancel_activity_yes">Yes, cancel running activity</string>
 </resources>


### PR DESCRIPTION
Lot of technical debt also removed along with this. Mainly in the UI update, inheritance, and observers architecture. 
TimerFragment only creates the buttons, textView. The child fragments populate as necessary.
Instead of callbacks being set to null (this was done _erroneously_ to solve #9), we now use observers. Cleans up a lot of code.
This should fix #26 