### PR TITLE
Pausing messes with the end calendar intent startTime

### DIFF
--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
@@ -188,6 +188,10 @@ open class TimerFragment : Fragment() {
         }
     }
 
+    open fun resumeSession() {
+        nextState()
+    }
+
     private fun changeState(state: State) {
         // when timer state changes
         when(state) {
@@ -207,7 +211,7 @@ open class TimerFragment : Fragment() {
                 startButton.text = view?.context?.getString(R.string.pomodoro_resume_session_button)
                 endButton.visibility = View.VISIBLE
                 controlButtonAction {
-                    startSession()
+                    resumeSession()
                 }
             }
 


### PR DESCRIPTION
Needed a new `resumeSession` function to avoid mutating the `startTime` every time session was resumed. This fixes #20 