### PR TITLE
calendar instance start time saved to DB, numblocks moved to timer

### DIFF
--- a/app/src/androidTest/java/com/example/beyondpomodoro/ActivityRunningConsistencyTest.kt
+++ b/app/src/androidTest/java/com/example/beyondpomodoro/ActivityRunningConsistencyTest.kt
@@ -328,10 +328,10 @@ allOf(withId(R.id.sessionListFragment),
 childAtPosition(
 withId(R.id.sessionListConstraintLayout),
 0)))
-        recyclerView2.perform(actionOnItemAtPosition<ViewHolder>(0, ViewActionClickRecyclerViewItem()))
-        
+        recyclerView2.perform(actionOnItemAtPosition<ViewHolder>(1, ViewActionClickRecyclerViewItem()))
+
         val materialButton10 = onView(
-allOf(withId(android.R.id.button1), withText("No"),
+allOf(withText("No")
 ))
         materialButton10.perform(scrollTo(), click())
         
@@ -340,7 +340,7 @@ allOf(withId(R.id.sessionListFragment),
 childAtPosition(
 withId(R.id.sessionListConstraintLayout),
 0)))
-        recyclerView3.perform(actionOnItemAtPosition<ViewHolder>(1, ViewActionClickRecyclerViewItem()))
+        recyclerView3.perform(actionOnItemAtPosition<ViewHolder>(0, ViewActionClickRecyclerViewItem()))
         
         val textView = onView(
 allOf(withId(R.id.activityName), withText("activity 1"),

--- a/app/src/androidTest/java/com/example/beyondpomodoro/SessionLessThanBreakTest.kt
+++ b/app/src/androidTest/java/com/example/beyondpomodoro/SessionLessThanBreakTest.kt
@@ -1,0 +1,146 @@
+package com.example.beyondpomodoro
+
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.TypeSafeMatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class SessionLessThanBreakTest {
+
+    @Rule
+    @JvmField
+    var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    @Test
+    fun sessionLessThanBreakTest() {
+        val floatingActionButton = onView(
+allOf(withId(R.id.newSessionTypeButton), withContentDescription("Create new session type"),
+childAtPosition(
+allOf(withId(R.id.sessionListConstraintLayout),
+childAtPosition(
+withId(R.id.nav_host_fragment_content_main),
+0)),
+1),
+isDisplayed()))
+        floatingActionButton.perform(click())
+        
+        val materialTextView = onView(
+allOf(withId(R.id.textView2), withText("25:00"),
+childAtPosition(
+allOf(withId(R.id.home_layout),
+childAtPosition(
+withId(R.id.nav_host_fragment_content_main),
+0)),
+4),
+isDisplayed()))
+        materialTextView.perform(click())
+        
+        val appCompatEditText = onView(
+allOf(withId(R.id.editTextSessionMinutes),
+childAtPosition(
+allOf(withId(R.id.linearLayout),
+childAtPosition(
+withId(android.R.id.content),
+0)),
+1),
+isDisplayed()))
+        appCompatEditText.perform(replaceText("1"), closeSoftKeyboard())
+        
+        val materialButton = onView(
+allOf(withId(R.id.set_time_button), withText("Set"),
+childAtPosition(
+allOf(withId(R.id.linearLayout),
+childAtPosition(
+withId(android.R.id.content),
+0)),
+2),
+isDisplayed()))
+        materialButton.perform(click())
+        
+        val materialButton2 = onView(
+allOf(withId(R.id.button), withText("Start"),
+isDisplayed()))
+        materialButton2.perform(click())
+        
+        val materialButton3 = onView(
+allOf(withId(R.id.button), withText("Pause"),
+isDisplayed()))
+        materialButton3.perform(click())
+        
+        val materialButton4 = onView(
+allOf(withId(R.id.button4), withText("End"),
+isDisplayed()))
+        materialButton4.perform(click())
+        
+        val materialButton5 = onView(
+allOf(withId(android.R.id.button2), withText("Discard"),
+))
+        materialButton5.perform(scrollTo(), click())
+        
+        val materialButton6 = onView(
+allOf(withId(R.id.button2), withText("Start"),
+isDisplayed()))
+        materialButton6.perform(click())
+        
+        val materialButton8 = onView(
+allOf(withId(R.id.button2), withText("Pause"),
+isDisplayed()))
+        materialButton8.perform(click())
+        
+        val materialButton9 = onView(
+allOf(withId(R.id.button3), withText("End"),
+isDisplayed()))
+        materialButton9.perform(click())
+        
+        val materialButton10 = onView(
+allOf(withId(R.id.button), withText("Start"),
+isDisplayed()))
+        materialButton10.perform(click())
+        
+        val materialButton11 = onView(
+allOf(withId(R.id.button), withText("Pause"),
+isDisplayed()))
+        materialButton11.perform(click())
+        
+        val materialButton12 = onView(
+allOf(withId(R.id.button4), withText("End"),
+isDisplayed()))
+        materialButton12.perform(click())
+        
+        val materialButton13 = onView(
+allOf(withId(android.R.id.button2), withText("Discard"),
+))
+        materialButton13.perform(scrollTo(), click())
+        }
+    
+    private fun childAtPosition(
+            parentMatcher: Matcher<View>, position: Int): Matcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("Child at position $position in parent ")
+                parentMatcher.describeTo(description)
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                val parent = view.parent
+                return parent is ViewGroup && parentMatcher.matches(parent)
+                        && view == parent.getChildAt(position)
+            }
+        }
+    }
+    }

--- a/app/src/main/java/com/example/beyondpomodoro/MainActivity.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.drawerlayout.widget.DrawerLayout
@@ -28,13 +29,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        println("DEBUG: destorying activity")
+        Log.d(localClassName, "DEBUG: destorying activity")
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        println("DEBUG: Creating activity")
+        Log.d(localClassName, "DEBUG: Creating activity")
         db = SessionDatabase.getInstance(this)
 
         // create timer service

--- a/app/src/main/java/com/example/beyondpomodoro/sessiontype/Session.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/sessiontype/Session.kt
@@ -32,9 +32,13 @@ data class Title (
     @PrimaryKey(autoGenerate = true) val sid: Int = 0
 )
 
+data class UseTime (
+    @ColumnInfo(name = "used_at") var usedAt: Long?,
+    @PrimaryKey(autoGenerate = true) val sid: Int = 0
+)
+
 data class Pomodoro (
     @ColumnInfo(name = "session_time") var sessionTime: Int?,
-    @ColumnInfo(name = "used_at") var usedAt: Long?,
     @ColumnInfo(name = "tags") var tags: Set<String>?,
     @ColumnInfo(name = "dnd") var dnd: Boolean = false,
     @PrimaryKey(autoGenerate = true) val sid: Int = 0
@@ -96,6 +100,9 @@ interface TagsDao {
 interface SessionDao {
     @Query("SELECT * FROM session WHERE used_at = (select MAX(s.used_at) from session as s)")
     suspend fun getLatestSession(): Session
+
+    @Update(entity = Session::class)
+    suspend fun activateSession(t: UseTime)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun addSession(session: Session): Long

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/BreakFragment.kt
@@ -139,7 +139,7 @@ class BreakFragment : TimerFragment() {
         }
 
         lifecycleScope.launch {
-            sessionId?.let {
+            sessionId.let {
                 sessionDao?.updateBreak(
                     Break(
                         breakTimeSeconds.toInt(),

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/HomeViewModel.kt
@@ -20,7 +20,6 @@ open class HomeViewModel : ViewModel() {
     var tags: MutableMap<String, String> = mutableMapOf()
 
     // event variables
-    var sessionStartTimeMillis: Long? = null
     var sessionEndTimeMillis: Long? = null
 
 

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/Notifications.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/Notifications.kt
@@ -27,17 +27,7 @@ fun persistentTimedNotification(context: Context, secondsUntilFinished: UInt, no
         .setOnlyAlertOnce(true)
         .setContentIntent(
             // Create the TaskStackBuilder
-            NavDeepLinkBuilder(context)
-            .setComponentName(MainActivity::class.java)
-            .setGraph(R.navigation.mobile_navigation)
-            .setDestination(
-                when(type) {
-                    "Pomodoro" -> R.id.pomodoroFragment
-                    "Break" -> R.id.breakFragment
-                    else -> R.id.sessionInfoFragment
-                }
-            )
-            .createPendingIntent()
+            openApp(context, type)
         )
         .addAction(R.drawable.ic_menu_send,
             action,

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/PomodoroTimer.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/PomodoroTimer.kt
@@ -2,6 +2,7 @@ package com.example.beyondpomodoro.ui.home
 
 import android.os.CountDownTimer
 import androidx.lifecycle.MutableLiveData
+import kotlin.math.floor
 
 
 enum class State {
@@ -25,6 +26,9 @@ enum class State {
 }
 
 class PomodoroTimer(sessionTimeSeconds: UInt) {
+    val percentage: MutableLiveData<UInt> by lazy {
+        MutableLiveData<UInt>(9u)
+    }
     val state: MutableLiveData<State> by lazy {
         MutableLiveData<State>(State.INACTIVE)
     }
@@ -75,10 +79,21 @@ class PomodoroTimer(sessionTimeSeconds: UInt) {
         }
     }
 
+    private fun updatePercentage() {
+        percentage.apply {
+            value = sessionTimeSeconds.value?.toDouble()?.let {
+                (sessionTimeSecondsLeft.value?.times(9u))?.toDouble()?.div(it)
+                    ?.let { floor(it).toUInt() }
+            }
+        }
+    }
+
     private fun updateVisualBlocks(millisUntilFinished: Long) {
         sessionTimeSecondsLeft.apply {
             value = (millisUntilFinished.toUInt())/1000u
         }
+
+        updatePercentage()
     }
 
     fun setSessionTime(s: UInt) {
@@ -86,6 +101,12 @@ class PomodoroTimer(sessionTimeSeconds: UInt) {
         sessionTimeSeconds.apply {
             value = s
         }
+
+        sessionTimeSecondsLeft.apply {
+            value = s
+        }
+
+        updatePercentage()
     }
 
     private fun onTimerFinish() {
@@ -105,6 +126,6 @@ class PomodoroTimer(sessionTimeSeconds: UInt) {
                 onTimerFinish()
             }
         }
+        updatePercentage()
     }
-
 }

--- a/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
+++ b/app/src/main/java/com/example/beyondpomodoro/ui/home/TimerFragment.kt
@@ -28,6 +28,7 @@ import com.example.beyondpomodoro.sessiontype.SessionDao
 import com.example.beyondpomodoro.sessiontype.TagsDao
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlin.properties.Delegates
 
 
 open class TimerFragment : Fragment() {
@@ -35,7 +36,7 @@ open class TimerFragment : Fragment() {
     protected var tags: MutableList<String> = mutableListOf()
     protected var breakTimeSeconds: UInt = 5u * 60u
     protected var sessionTimeSeconds: UInt = 25u * 60u
-    protected var sessionId: Int? = null
+    protected var sessionId by Delegates.notNull<Int>()
     protected var title: String? = null
 
     lateinit var startButton: Button
@@ -71,6 +72,9 @@ open class TimerFragment : Fragment() {
             })
             timer.state.observe(viewLifecycleOwner, {
                 changeState(it)
+            })
+            timer.percentage.observe(viewLifecycleOwner, {
+                updateVisualBlocks(it)
             })
         }
 
@@ -117,17 +121,14 @@ open class TimerFragment : Fragment() {
             }?: run {
                 sessionDao?.getLatestSession()?.apply {
                     readSession(this)
-                    sessionId?.let { setRunningActivityId(activity, it) }
+                    sessionId.let { setRunningActivityId(activity, it) }
                 }
             }
-
-
-
 
             addButtons()
             bindCallbacks()
             lifecycleScope.launch {
-                sessionId?.let {
+                sessionId.let {
                     sessionDao?.getTitle(it)?.let { s ->
                         s.collect { t ->
                             title = t
@@ -137,7 +138,7 @@ open class TimerFragment : Fragment() {
                 }
             }
             lifecycleScope.launch {
-                sessionId?.let {
+                sessionId.let {
                     sessionDao?.getDnd(it)?.let { s ->
                         s.collect { d ->
                             dnd = d
@@ -359,12 +360,9 @@ open class TimerFragment : Fragment() {
     open fun onTick(secondsLeft: UInt) {
 
         textViewSeconds.text = convertMinutesToDisplayString(secondsLeft)
-
-        // update visuals
-        updateVisualBlocks(secondsLeft)
     }
 
-    open fun updateVisualBlocks(secondsUntilFinished: UInt) {
+    open fun updateVisualBlocks(numBlocks: UInt) {
     }
 
     fun timerReset() {


### PR DESCRIPTION
calculating numblocks in the timer reduces chances of bad or laggy
updates from obervers (since two values are observed and a result
calculated from them)

Fixes #63 and other issues with numblocks calculation.